### PR TITLE
Create release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Publish release on push to main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get current date as version
+        run: echo "VERSION=$(date +'%y.%m.%d')" >> $GITHUB_ENV
+
+      - name: Set up binaries directory
+        run: mkdir -p binaries
+
+      - name: Build binary for Linux
+        run: |
+          cargo build --release --target x86_64-unknown-linux-gnu
+          mv target/release/file_date_fixer binaries/file_date_fixer-linux
+
+      - name: Build binary for Windows
+        run: |
+          cargo build --release --target x86_64-pc-windows-gnu
+          mv target/release/file_date_fixer.exe binaries/file_date_fixer-windows.exe
+
+      - name: Create Github release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "${{ env.VERSION }}"
+          name: "${{ env.VERSION }}"
+          draft: false
+          prerelease: true
+          files: binaries/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,15 +20,28 @@ jobs:
       - name: Set up binaries directory
         run: mkdir -p binaries
 
+      - name: Add Windows target
+        run: |
+          apt update && apt install -y mingw-w64
+          rustup target add x86_64-pc-windows-gnu
+
       - name: Build binary for Linux
         run: |
           cargo build --release --target x86_64-unknown-linux-gnu
-          mv target/release/file_date_fixer binaries/file_date_fixer-linux
+          mv target/release/x86_64-pc-windows-gnu/file_date_fixer binaries/file_date_fixer-linux
 
       - name: Build binary for Windows
         run: |
           cargo build --release --target x86_64-pc-windows-gnu
-          mv target/release/file_date_fixer.exe binaries/file_date_fixer-windows.exe
+          mv target/release/x86_64-pc-windows-gnu/file_date_fixer.exe binaries/file_date_fixer-windows.exe
+
+      - name: Delete existing release if exists
+        continue-on-error: true
+        run: |
+          gh release delete "${{ env.VERSION }}" --yes
+          gh tag delete "${{ env.VERSION }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Github release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Every time a commit is pushed to the `main` branch, a release is created with the corresponding binary assets for both Linux and Windows