### PR TITLE
Standarize file date modification

### DIFF
--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -23,8 +23,11 @@ jobs:
       - name: Run Clippy (Linter)
         run: cargo clippy -- -D warnings
 
-      - name: Build project
-        run: cargo build
+      - name: Build project for Linux
+        run: cargo build --target x86_64-unknown-linux-gnu
+
+      - name: Build project for Windows
+        run: cargo build --target x86_64-pc-windows-gnu
 
       - name: Run tests
         run: cargo test

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Build project for Linux
         run: cargo build --target x86_64-unknown-linux-gnu
 
+      - name: Add Windows target
+        run: |
+          sudo apt update && sudo apt install -y mingw-w64
+          rustup target add x86_64-pc-windows-gnu
+
       - name: Build project for Windows
         run: cargo build --target x86_64-pc-windows-gnu
 

--- a/src/file_metadata/common.rs
+++ b/src/file_metadata/common.rs
@@ -1,0 +1,16 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use std::fs;
+use std::path::Path;
+use std::time::SystemTime;
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+compile_error!("This program only supports Windows and Linux.");
+
+pub fn get_file_date(
+    path: &Path,
+    time_fn: fn(&fs::Metadata) -> std::io::Result<SystemTime>,
+) -> Option<NaiveDate> {
+    let metadata = fs::metadata(path).ok()?;
+    let system_time = time_fn(&metadata).ok()?;
+    Some(DateTime::<Utc>::from(system_time).date_naive())
+}

--- a/src/file_metadata/linux.rs
+++ b/src/file_metadata/linux.rs
@@ -1,5 +1,5 @@
 #[cfg(target_os = "linux")]
-mod linux {
+mod linux_only {
     use chrono::NaiveDate;
     use filetime::{set_file_mtime, FileTime};
     use std::fs::Metadata;
@@ -25,4 +25,4 @@ mod linux {
 }
 
 #[cfg(target_os = "linux")]
-pub use linux::*;
+pub use linux_only::*;

--- a/src/file_metadata/linux.rs
+++ b/src/file_metadata/linux.rs
@@ -1,0 +1,22 @@
+use chrono::NaiveDate;
+use filetime::{set_file_mtime, FileTime};
+use std::fs::Metadata;
+use std::io::Error;
+use std::path::Path;
+
+use super::common::get_file_date;
+
+pub fn get_file_modification_date(path: &Path) -> Option<NaiveDate> {
+    get_file_date(path, Metadata::modified)
+}
+
+#[cfg(target_os = "linux")]
+pub fn set_file_modification_date(path: &Path, new_date: NaiveDate) -> Result<(), Error> {
+    let new_file_time = FileTime::from_unix_time(
+        new_date.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp(),
+        0,
+    );
+
+    set_file_mtime(path, new_file_time)?;
+    Ok(())
+}

--- a/src/file_metadata/linux.rs
+++ b/src/file_metadata/linux.rs
@@ -1,22 +1,28 @@
-use chrono::NaiveDate;
-use filetime::{set_file_mtime, FileTime};
-use std::fs::Metadata;
-use std::io::Error;
-use std::path::Path;
+#[cfg(target_os = "linux")]
+mod linux {
+    use chrono::NaiveDate;
+    use filetime::{set_file_mtime, FileTime};
+    use std::fs::Metadata;
+    use std::io::Error;
+    use std::path::Path;
 
-use super::common::get_file_date;
+    use super::super::common::get_file_date;
 
-pub fn get_file_modification_date(path: &Path) -> Option<NaiveDate> {
-    get_file_date(path, Metadata::modified)
+    pub fn get_file_modification_date(path: &Path) -> Option<NaiveDate> {
+        get_file_date(path, Metadata::modified)
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn set_file_modification_date(path: &Path, new_date: NaiveDate) -> Result<(), Error> {
+        let new_file_time = FileTime::from_unix_time(
+            new_date.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp(),
+            0,
+        );
+
+        set_file_mtime(path, new_file_time)?;
+        Ok(())
+    }
 }
 
 #[cfg(target_os = "linux")]
-pub fn set_file_modification_date(path: &Path, new_date: NaiveDate) -> Result<(), Error> {
-    let new_file_time = FileTime::from_unix_time(
-        new_date.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp(),
-        0,
-    );
-
-    set_file_mtime(path, new_file_time)?;
-    Ok(())
-}
+pub use linux::*;

--- a/src/file_metadata/mod.rs
+++ b/src/file_metadata/mod.rs
@@ -1,0 +1,3 @@
+mod common;
+pub mod linux;
+pub mod windows;

--- a/src/file_metadata/windows.rs
+++ b/src/file_metadata/windows.rs
@@ -1,5 +1,5 @@
 #[cfg(target_os = "windows")]
-mod windows {
+mod windows_only {
     use chrono::NaiveDate;
     use filetime::FileTime;
     use filetime_creation::set_file_ctime;
@@ -40,4 +40,4 @@ mod windows {
 }
 
 #[cfg(target_os = "windows")]
-pub use windows::*;
+pub use windows_only::*;

--- a/src/file_metadata/windows.rs
+++ b/src/file_metadata/windows.rs
@@ -1,37 +1,43 @@
-use chrono::NaiveDate;
-use filetime::FileTime;
-use filetime_creation::set_file_ctime;
-use std::fs::Metadata;
-use std::io::Error;
-use std::path::Path;
+#[cfg(target_os = "windows")]
+mod windows {
+    use chrono::NaiveDate;
+    use filetime::FileTime;
+    use filetime_creation::set_file_ctime;
+    use std::fs::Metadata;
+    use std::io::Error;
+    use std::path::Path;
 
-use super::common::get_file_date;
+    use super::super::common::get_file_date;
 
-pub fn get_file_creation_date(path: &Path) -> Option<NaiveDate> {
-    get_file_date(path, Metadata::created)
+    pub fn get_file_creation_date(path: &Path) -> Option<NaiveDate> {
+        get_file_date(path, Metadata::created)
+    }
+
+    #[cfg(target_os = "windows")]
+    pub fn set_file_creation_date(path: &Path, new_date: NaiveDate) -> Result<(), Error> {
+        let new_date_time = new_date.and_hms_opt(0, 0, 0).ok_or_else(|| {
+            Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Invalid date. Could not convert date to datetime",
+            )
+        })?;
+
+        let utc_date_time = new_date_time.and_utc();
+        let unix_timestamp = utc_date_time.timestamp();
+        let nanos = utc_date_time.timestamp_subsec_nanos();
+
+        let filetime = FileTime::from_unix_time(unix_timestamp, nanos);
+
+        set_file_ctime(path, filetime).map_err(|e| {
+            Error::new(
+                std::io::ErrorKind::Other,
+                format!("Failed to set file creation time for {:?}: {}", path, e),
+            )
+        })?;
+
+        Ok(())
+    }
 }
 
 #[cfg(target_os = "windows")]
-pub fn set_file_creation_date(path: &Path, new_date: NaiveDate) -> Result<(), Error> {
-    let new_date_time = new_date.and_hms_opt(0, 0, 0).ok_or_else(|| {
-        Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "Invalid date. Could not convert date to datetime",
-        )
-    })?;
-
-    let utc_date_time = new_date_time.and_utc();
-    let unix_timestamp = utc_date_time.timestamp();
-    let nanos = utc_date_time.timestamp_subsec_nanos();
-
-    let filetime = FileTime::from_unix_time(unix_timestamp, nanos);
-
-    set_file_ctime(path, filetime).map_err(|e| {
-        Error::new(
-            std::io::ErrorKind::Other,
-            format!("Failed to set file creation time for {:?}: {}", path, e),
-        )
-    })?;
-
-    Ok(())
-}
+pub use windows::*;

--- a/src/file_metadata/windows.rs
+++ b/src/file_metadata/windows.rs
@@ -1,22 +1,18 @@
-use chrono::{DateTime, NaiveDate, Utc};
-use std::fs;
+use chrono::NaiveDate;
+use filetime::FileTime;
+use filetime_creation::set_file_ctime;
+use std::fs::Metadata;
 use std::io::Error;
 use std::path::Path;
 
-#[cfg(not(any(target_os = "windows", target_os = "linux")))]
-compile_error!("This program only supports Windows and Linux.");
+use super::common::get_file_date;
 
 pub fn get_file_creation_date(path: &Path) -> Option<NaiveDate> {
-    let metadata = fs::metadata(path).ok()?;
-    let system_time = metadata.created().or_else(|_| metadata.modified()).ok()?;
-    Some(DateTime::<Utc>::from(system_time).date_naive())
+    get_file_date(path, Metadata::created)
 }
 
 #[cfg(target_os = "windows")]
 pub fn set_file_creation_date(path: &Path, new_date: NaiveDate) -> Result<(), Error> {
-    use filetime::FileTime;
-    use filetime_creation::set_file_ctime;
-
     let new_date_time = new_date.and_hms_opt(0, 0, 0).ok_or_else(|| {
         Error::new(
             std::io::ErrorKind::InvalidInput,
@@ -37,16 +33,5 @@ pub fn set_file_creation_date(path: &Path, new_date: NaiveDate) -> Result<(), Er
         )
     })?;
 
-    Ok(())
-}
-
-#[cfg(target_os = "linux")]
-pub fn set_file_creation_date(path: &Path, new_date: NaiveDate) -> Result<(), Error> {
-    use filetime::{set_file_times, FileTime};
-    let new_file_time = FileTime::from_unix_time(
-        new_date.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp(),
-        0,
-    );
-    set_file_times(path, new_file_time, new_file_time)?;
     Ok(())
 }

--- a/src/file_processor/file.rs
+++ b/src/file_processor/file.rs
@@ -26,7 +26,7 @@ pub fn process_file(file_path: &Path, file_name: &str) {
 
     debug(&format!("Processing file: {}", file_name));
 
-    if is_normalized_date_pattern_match(file_name) {
+    if is_normalized_date_pattern_match(normalized_file_name.as_str()) {
         process_matched_pattern_file(file_path, file_name, &normalized_file_name);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
         std::process::exit(1);
     }
 
-    info("Starting file date normalization process");
+    info("Starting file date fix process");
 
     process_dir(dir_path, args.recursive);
 }


### PR DESCRIPTION
Make file date modification process standard for both Linux and Windows, leaving the date getting and setting process for the target-specific module.

Windows module will obtain and modify the creation date, whereas the Linux module will do the same for the modification date.